### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: 'recursive'
       - name: Publish Docker
         if: ${{ github.repository == 'BC-SECURITY/Empire' }}
-        uses: elgohr/Publish-Docker-Github-Action@2.9
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bcsecurity/empire
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore